### PR TITLE
Don't list MacOS temp files, beginning with '._'

### DIFF
--- a/loadImageWithSubfolders-NoTemp.py
+++ b/loadImageWithSubfolders-NoTemp.py
@@ -6,6 +6,7 @@ import hashlib
 from PIL import Image, ImageOps
 from PIL.PngImagePlugin import PngInfo
 import numpy as np
+import re
 
 class LoadImage:
     @classmethod
@@ -21,7 +22,8 @@ class LoadImage:
             for file in files:
                 file_path = os.path.relpath(os.path.join(root, file), start=input_dir)
                 file_path = file_path.replace("\\", "/")  # so the filename is processed correctly in widgets.js
-                file_list.append(file_path)
+                if not re.search('^\._', file):
+                    file_list.append(file_path)
 
         return {"required":
                     {"image": (sorted(file_list), {"image_upload": True})},


### PR DESCRIPTION
Forked to add an If statement, testing whether a file begins with '._' before adding it to the file list. Added 'import re' for the regex search. 

Files that begin with '._' are sidecar files that contain metadata that doesn't fit neatly into the filesystem, made by MacOS. They take up space in the file list and break things if selected by mistake.

There's probably a better way to do this*, but it seems to work, and didn't cause any problems in my limited testing.


*: probably something like 
```
        # filter by prefix
        invalid_prefixes = ['._']
        dir_files2 = dir_files
        for f in dir_files2[:]:
            for prefix in invalid_prefixes:
                if f.lower().startswith(prefix):
                    dir_files2.remove(f)
        dir_files = dir_files2
```